### PR TITLE
Fixes issues when not using the default vpc or subnet

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,7 @@ resource "aws_instance" "my_server" {
   instance_type          = var.instance_type
   key_name               = aws_key_pair.deployer.key_name
   vpc_security_group_ids = [aws_security_group.my_server.id]
+  subnet_id              = var.subnet_id
 
   tags = {
     Name = var.instance_name

--- a/variables.tf
+++ b/variables.tf
@@ -64,4 +64,5 @@ variable "instance_name" {
 variable "vpc_id" {
   type        = string
   description = "(Optional) VPC id to use in security groups. Will use the default vpc in the region if unspecified"
+  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -66,3 +66,9 @@ variable "vpc_id" {
   description = "(Optional) VPC id to use in security groups. Will use the default vpc in the region if unspecified"
   default     = null
 }
+
+variable "subnet_id" {
+  type        = string
+  description = "(Optional) Subnet id to use for the ec2 instance. Will select from one of the default subnets if not specified"
+  default     = null
+}


### PR DESCRIPTION
## What this PR does

- [x] Fixes bug where `vpc_id` is a required variable (might just need the default vpc)
- [x] Fixes  bug when using a custom vpc where ec2 instance uses one of the default subnet resulting in a vpc-subnet mismatch
	- Allows passing `subnet_id`